### PR TITLE
Add Clantag module as alternative HUD & few other changes

### DIFF
--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
@@ -7,6 +7,11 @@ stock void EWM_Clantag_OnPluginStart()
 	CreateTimer(1.0, EWM_Clantag_Timer_UpdateClantag, _, TIMER_REPEAT);
 }
 
+stock void EWM_Clantag_OnPluginEnd()
+{
+	EWM_Clantag_Mass_Reset();
+}
+
 stock void EWM_Clantag_OnMapEnd()
 {
 	EWM_Clantag_Mass_Reset();
@@ -17,10 +22,17 @@ stock void EWM_Clantag_Event_RoundEnd()
 	EWM_Clantag_Mass_Reset();
 }
 
+stock void EWM_Clantag_OnClientDisconnect(int client)
+{
+	//Clear stored clantag	
+	Format(g_sClanTag[client], sizeof(g_sClanTag[]), "");	
+}
+
 stock void EWM_Clantag_Mass_Reset()
 {
 	for (int i = 1; i <= MaxClients; i++) {
 		EWM_Clantag_Reset(i);
+		Format(g_sClanTag[i], sizeof(g_sClanTag[]), "");
 	}
 }
 
@@ -157,7 +169,7 @@ stock void EWM_Clantag_Reset(int client)
 		} else {
 			CS_SetClientClanTag(client, g_sClanTag[client]);
 		}			
-	}		
-		
+	}
+	
 	CS_SetClientContributionScore(client, 0);
 }

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
@@ -1,0 +1,163 @@
+#define EW_MODULE_CLANTAG
+
+char g_sClanTag[MAXPLAYERS + 1][128];
+
+stock void EWM_Clantag_OnPluginStart()
+{
+	CreateTimer(1.0, EWM_Clantag_Timer_UpdateClantag, _, TIMER_REPEAT);
+}
+
+stock void EWM_Clantag_OnMapEnd()
+{
+	EWM_Clantag_Mass_Reset();
+}
+
+stock void EWM_Clantag_Event_RoundEnd()
+{
+	EWM_Clantag_Mass_Reset();
+}
+
+stock void EWM_Clantag_Mass_Reset()
+{
+	for (int i = 1; i <= MaxClients; i++) {
+		EWM_Clantag_Reset(i);
+	}
+}
+
+public Action EWM_Clantag_Timer_UpdateClantag(Handle timer, int client)
+{
+	if (g_bConfigLoaded)
+	{
+		char buffer_temp[128];
+		
+		for(int i = 0; i < g_ItemList.Length; i++)
+		{
+			class_ItemList ItemTest;
+			g_ItemList.GetArray(i, ItemTest, sizeof(ItemTest));
+			if (ItemTest.Hud && ItemTest.OwnerID != INVALID_ENT_REFERENCE && IsValidEdict(ItemTest.WeaponID))
+			{
+				if(ItemTest.Delay > 0)
+				{
+					FormatEx(buffer_temp, sizeof(buffer_temp), "%s[-%d]:", ItemTest.ShortName, ItemTest.Delay);					
+				}
+				else
+				{
+					switch(ItemTest.Mode)
+					{
+						case 2:
+						{
+							if (ItemTest.CoolDownTime > 0)
+							{
+								FormatEx(buffer_temp, sizeof(buffer_temp), "%s[%d]:", ItemTest.ShortName, ItemTest.CoolDownTime);
+							}
+							else
+							{
+								FormatEx(buffer_temp, sizeof(buffer_temp), "%s[R]:", ItemTest.ShortName);
+							}
+						}
+						case 3:
+						{
+							if (ItemTest.Uses < ItemTest.MaxUses)
+							{
+								FormatEx(buffer_temp, sizeof(buffer_temp), "%s[%d/%d]:", ItemTest.ShortName, ItemTest.Uses, ItemTest.MaxUses);
+							}
+							else
+							{
+								FormatEx(buffer_temp, sizeof(buffer_temp), "%s[D]:", ItemTest.ShortName);
+							}
+						}
+						case 4:
+						{
+							if (ItemTest.CoolDownTime > 0)
+							{
+
+								FormatEx(buffer_temp, sizeof(buffer_temp), "%s[%d]:", ItemTest.ShortName, ItemTest.CoolDownTime);
+							}
+							else
+								if (ItemTest.Uses < ItemTest.MaxUses)
+								{
+									FormatEx(buffer_temp, sizeof(buffer_temp), "%s[%d/%d]:", ItemTest.ShortName, ItemTest.Uses, ItemTest.MaxUses);
+								}
+								else
+								{
+									FormatEx(buffer_temp, sizeof(buffer_temp), "%s[D]:", ItemTest.ShortName);
+								}
+						}
+						case 5:
+						{
+							if (ItemTest.CoolDownTime > 0)
+							{
+								FormatEx(buffer_temp, sizeof(buffer_temp), "%s[%d]:", ItemTest.ShortName, ItemTest.CoolDownTime);
+							}
+							else
+							{
+								FormatEx(buffer_temp, sizeof(buffer_temp), "%s[%d/%d]:", ItemTest.ShortName, ItemTest.Uses, ItemTest.MaxUses);
+							}
+						}
+						default:
+						{
+							FormatEx(buffer_temp, sizeof(buffer_temp), "%s[N/A]:", ItemTest.ShortName);
+						}
+					}
+				}
+				if (IsValidClient(ItemTest.OwnerID)) {
+					if (IsPlayerAlive(ItemTest.OwnerID)) {
+						CS_SetClientClanTag(ItemTest.OwnerID, buffer_temp);
+					}
+				}
+			}
+		}
+	}
+	return Plugin_Continue;
+}
+
+stock void EWM_Clantag_PickUp(class_ItemList ItemTest, int iClient)
+{
+	if (!IsValidClient(iClient))
+		return;
+		
+	CS_GetClientClanTag(iClient, g_sClanTag[iClient], sizeof(g_sClanTag[]));
+	
+	if (strlen(g_sClanTag[iClient]) <= 0)
+	{
+		g_sClanTag[iClient][0] = ' ';
+		g_sClanTag[iClient][1] = '\0';
+	}	
+	
+	char buffer_temp[128];
+	FormatEx(buffer_temp, sizeof(buffer_temp), "%s[N/A]:", ItemTest.ShortName);
+	CS_SetClientClanTag(iClient, buffer_temp);
+	CS_SetClientContributionScore(iClient, 9999);
+}
+
+stock void EWM_Clantag_Drop(class_ItemList ItemTest, int iClient)
+{
+	EWM_Clantag_Reset(iClient);
+}
+
+stock void EWM_Clantag_PlayerDeath(class_ItemList ItemTest, int iClient)
+{
+	EWM_Clantag_Reset(iClient);
+}
+
+stock void EWM_Clantag_PlayerDeath_Drop(class_ItemList ItemTest, int iClient)
+{
+	EWM_Clantag_Reset(iClient);
+}
+
+stock void EWM_Clantag_Reset(int client)
+{
+	if (!IsValidClient(client))
+		return;
+		
+	if (strlen(g_sClanTag[client]) > 0)
+	{
+		if (g_sClanTag[client][1] == '\0' && g_sClanTag[client][0] == ' ') {
+			CS_SetClientClanTag(client, "");
+		} else {
+			CS_SetClientClanTag(client, g_sClanTag[client]);
+		}			
+	}		
+		
+	CS_SetClientContributionScore(client, 0);
+}

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_eban.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_eban.inc
@@ -186,6 +186,15 @@ public void EWM_Eban_BanClient(int iClient, int iAdmin, int iDuration, const cha
 			CPrintToChatAll("%s%t %s%s %s%t %s%N% %s%t. %s%t: %s", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Name, sAdmin_Name, g_SchemeConfig.Color_Disabled, "Restricted", g_SchemeConfig.Color_Name, iClient, g_SchemeConfig.Color_Enabled, "Temporary", g_SchemeConfig.Color_Warning, "Reason", sReason);
 		}else if(iBanDuration == 0)
 		{
+			//Wesker EDIT -- Restrict perma bans with command override
+			if(iAdmin != 0)
+			{
+				//Check if admin has permission
+				if (!CheckCommandAccess(iAdmin, "sm_eban_perm", ADMFLAG_ROOT)) {
+					CPrintToChat(iAdmin, "{green}[Entwatch] {lightblue}You do not have permission to permanently eBan.");
+					return;
+				}
+			}
 			//Permament
 			g_EbanClients[iClient].Banned = true;
 			FormatEx(g_EbanClients[iClient].Admin_Name, 32, "%s", sAdmin_Name);
@@ -211,6 +220,15 @@ public void EWM_Eban_BanClient(int iClient, int iAdmin, int iDuration, const cha
 			CPrintToChatAll("%s%t %s%s %s%t %s%N %s%t. %s%t: %s", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Name, sAdmin_Name, g_SchemeConfig.Color_Disabled, "Restricted", g_SchemeConfig.Color_Name, iClient, g_SchemeConfig.Color_Disabled, "Permanently", g_SchemeConfig.Color_Warning, "Reason", sReason);
 		}else
 		{
+			//Wesker EDIT -- Restrict longer bans with command override
+			if(iAdmin != 0 && iBanDuration >= 720)
+			{
+				//Check if admin has permission
+				if (!CheckCommandAccess(iAdmin, "sm_eban_long", ADMFLAG_ROOT)) {
+					CPrintToChat(iAdmin, "{green}[Entwatch] {lightblue}You do not have permission to eBan longer than 12 hours.");
+					return;
+				}
+			}
 			//Duration
 			g_EbanClients[iClient].Banned = true;
 			FormatEx(g_EbanClients[iClient].Admin_Name, 32, "%s", sAdmin_Name);
@@ -265,8 +283,19 @@ public void EWM_Eban_UnBanClient(int iClient, int iAdmin, const char[] sReason)
 {
 	char sAdmin_Name[32];
 	char sAdmin_SteamID[64];
-	if(iAdmin != 0)
+	if (iAdmin != 0)
 	{
+		//WESKER EDIT -- Restrict perma unbans with command override
+		int iBanDuration = g_EbanClients[iClient].Duration;
+		if (iBanDuration == 0)
+		{
+				//Check if admin has permission
+				if (!CheckCommandAccess(iAdmin, "sm_eban_perm", ADMFLAG_ROOT)) {
+					CPrintToChat(iAdmin, "{green}[Entwatch] {lightblue}You do not have permission to remove permanent eBans.");
+					return;
+				}
+		}
+		
 		//Admin
 		FormatEx(sAdmin_Name, sizeof(sAdmin_Name), "%N", iAdmin);
 		GetClientAuthId(iAdmin, AuthId_Steam2, sAdmin_SteamID, sizeof(sAdmin_SteamID));

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_glow.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_glow.inc
@@ -23,8 +23,8 @@ stock void EWM_Glow_OnPluginStart()
 {
 	g_hCvar_Glow              = CreateConVar("entwatch_glow", "1", "Enable/Disable the glow Global.", _, true, 0.0, true, 1.0);
 	g_hCvar_Glow_Spawn        = CreateConVar("entwatch_glow_spawn", "1", "Enable/Disable the glow after Spawn Items.", _, true, 0.0, true, 1.0);
-	g_hCvar_Glow_Spawn_Type   = CreateConVar("entwatch_glow_spawn_type", "0", "Glow Type after Spawn Items.", _, true, 0.0, true, 3.0);
-	g_hCvar_Glow_Drop_Type    = CreateConVar("entwatch_glow_drop_type", "0", "Glow Type after Drop Items.", _, true, 0.0, true, 3.0);
+	g_hCvar_Glow_Spawn_Type   = CreateConVar("entwatch_glow_spawn_type", "0", "Glow Type after Spawn Items.", _, true, -1.0, true, 3.0);
+	g_hCvar_Glow_Drop_Type    = CreateConVar("entwatch_glow_drop_type", "0", "Glow Type after Drop Items.", _, true, -1.0, true, 3.0);
 
 	HookConVarChange(g_hCvar_Glow, Cvar_GLOW_Changed);
 	HookConVarChange(g_hCvar_Glow_Spawn, Cvar_GLOW_Changed);
@@ -74,6 +74,18 @@ stock void EWM_Glow_GlowWeapon(class_ItemList ItemTest, int index, bool bSpawn)
 {
 	if(g_bGlow && g_bMapRunning)
 	{
+		//WESKER EDIT -- Set drop type negative to disable glow on dropped items
+		if (!bSpawn && g_iGlow_Drop_Type < 0) {
+			if (ItemTest.GlowEnt != INVALID_ENT_REFERENCE && IsValidEdict(ItemTest.GlowEnt))
+			{
+				AcceptEntityInput(ItemTest.GlowEnt, "Kill");
+			}
+			return;
+		} else if (bSpawn && g_iGlow_Spawn_Type < 0) {
+			//WESKER EDIT -- Set spawn type negative to disable glow on new items
+			return;
+		}
+		
 		if(ItemTest.GlowEnt == INVALID_ENT_REFERENCE || !IsValidEdict(ItemTest.GlowEnt))
 		{
 			char sModelPath[PLATFORM_MAX_PATH];

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_offline_eban.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_offline_eban.inc
@@ -10,7 +10,7 @@ ArrayList g_OfflineArray;
 
 class_Offline_Eban g_aMenuBuffer[MAXPLAYERS+1];
 
-stock void EWM_OffilneEban_OnPluginStart()
+stock void EWM_OfflineEban_OnPluginStart()
 {
 	g_OfflineArray = new ArrayList(512);
 	
@@ -42,7 +42,7 @@ Action EWM_OfflineEban_Timer_Checker(Handle timer)
 	return Plugin_Continue;
 }
 
-public void EWM_OffilneEban_OnClientPutInServer(int iClient)
+public void EWM_OfflineEban_OnClientPutInServer(int iClient)
 {
 	if(IsFakeClient(iClient)) return;
 	
@@ -80,7 +80,7 @@ public void EWM_OffilneEban_OnClientPutInServer(int iClient)
 	}
 }
 
-public void EWM_OffilneEban_OnClientDisconnect(int iClient)
+public void EWM_OfflineEban_OnClientDisconnect(int iClient)
 {
 	if(IsFakeClient(iClient)) return;
 	
@@ -115,7 +115,7 @@ public void EWM_OffilneEban_OnClientDisconnect(int iClient)
 	}
 }
 
-public void EWM_OffilneEban_UpdateItemName(int iClient, const char[] sNameItem)
+public void EWM_OfflineEban_UpdateItemName(int iClient, const char[] sNameItem)
 {
 	if(IsFakeClient(iClient)) return;
 	
@@ -149,7 +149,7 @@ public void EWM_OffilneEban_UpdateItemName(int iClient, const char[] sNameItem)
 	}
 }
 
-public void EWM_OffilneEban_BanClient(class_Offline_Eban cPlayer, int iAdmin, int iDuration, const char[] sReason)
+public void EWM_OfflineEban_BanClient(class_Offline_Eban cPlayer, int iAdmin, int iDuration, const char[] sReason)
 {
 	char sAdmin_Name[32];
 	char sAdmin_SteamID[64];
@@ -414,7 +414,7 @@ public int EWM_OfflineEban_Reason_Handler(Menu hMenu, MenuAction hAction, int iC
 			ExplodeString(sSelected, "/", Explode_sParam, 2, 64);
 			int iDuration = StringToInt(Explode_sParam[0]);
 			FormatEx(sReason, sizeof(sReason), "%s", Explode_sParam[1]);
-			EWM_OffilneEban_BanClient(g_aMenuBuffer[iClient], iClient, iDuration, sReason);
+			EWM_OfflineEban_BanClient(g_aMenuBuffer[iClient], iClient, iDuration, sReason);
 		}
 	}
 }

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch_csgo_dz.sp
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch_csgo_dz.sp
@@ -52,6 +52,10 @@ bool g_bIsAdmin[MAXPLAYERS+1] = {false,...};
 #include "entwatch/module_glow.inc"
 #include "entwatch/module_use_priority.inc"
 #include "entwatch/module_extended_logs.inc"
+
+//WESKER MODULE
+#include "entwatch/module_clantag.inc"
+
 //#include "entwatch/module_physbox.inc" //Heavy module for the server. Not recommended. Need Collision Hook Ext https://forums.alliedmods.net/showthread.php?t=197815
 //#include "entwatch/module_debug.inc"
 //End Section Modules
@@ -65,7 +69,7 @@ public Plugin myinfo =
 	name = "EntWatch",
 	author = "DarkerZ[RUS]",
 	description = "Notify players about entity interactions.",
-	version = "3.DZ.11",
+	version = "3.DZ.12",
 	url = "dark-skill.ru"
 };
  
@@ -136,6 +140,11 @@ public void OnPluginStart()
 	EWM_Debug_OnPluginStart();
 	#endif
 	
+	//WESKER MODULE CLANTAG
+	#if defined EW_MODULE_CLANTAG
+	EWM_Clantag_OnPluginStart();
+	#endif
+	
 	LoadTranslations("EntWatch_DZ.phrases");
 	LoadTranslations("common.phrases");
 	
@@ -175,6 +184,10 @@ public void OnMapEnd()
 {
 	#if defined EW_MODULE_GLOW
 	EWM_Glow_OnMapEnd();
+	#endif
+	
+	#if defined EW_MODULE_CLANTAG
+	EWM_Clantag_OnMapEnd();
 	#endif
 }
 
@@ -216,6 +229,10 @@ public Action Event_RoundEnd(Event hEvent, const char[] sName, bool bDontBroadca
 		#if defined EW_MODULE_PHYSBOX
 		EWM_Physbox_Event_RoundEnd();
 		#endif
+		
+		#if defined EW_MODULE_CLANTAG
+		EWM_Clantag_Event_RoundEnd();
+		#endif
 	}
 }
 
@@ -250,6 +267,10 @@ public Action Event_PlayerDeath(Event hEvent, const char[] sName, bool bDontBroa
 						#if defined EW_MODULE_CHAT
 						if(ItemTest.Chat) EWM_Chat_PlayerDeath_Drop(ItemTest, iClient);
 						#endif
+						
+						#if defined EW_MODULE_CLANTAG
+						EWM_Clantag_PlayerDeath_Drop(ItemTest, iClient);
+						#endif
 					}
 					else
 					{
@@ -257,6 +278,10 @@ public Action Event_PlayerDeath(Event hEvent, const char[] sName, bool bDontBroa
 						{
 							#if defined EW_MODULE_CHAT
 							if(ItemTest.Chat) EWM_Chat_PlayerDeath(ItemTest, iClient);
+							#endif
+							
+							#if defined EW_MODULE_CLANTAG
+							EWM_Clantag_PlayerDeath(ItemTest, iClient);
 							#endif
 							AcceptEntityInput(ItemTest.WeaponID, "Kill");
 						}else
@@ -266,8 +291,13 @@ public Action Event_PlayerDeath(Event hEvent, const char[] sName, bool bDontBroa
 							{
 								SDKHooks_DropWeapon(iClient, ItemTest.WeaponID);
 								EWM_Chat_PlayerDeath_Drop(ItemTest, iClient);
-							} else
+							}
 							#endif
+							
+							#if defined EW_MODULE_CLANTAG
+							EWM_Clantag_PlayerDeath_Drop(ItemTest, iClient);
+							#endif
+							
 							SDKHooks_DropWeapon(iClient, ItemTest.WeaponID);
 						}
 					}
@@ -340,6 +370,7 @@ public void OnClientDisconnect(int iClient)
 							#if defined EW_MODULE_CHAT
 							if(ItemTest.Chat) EWM_Chat_Disconnect(ItemTest, iClient);
 							#endif
+							
 							AcceptEntityInput(ItemTest.WeaponID, "Kill");
 						}else
 						{
@@ -350,6 +381,7 @@ public void OnClientDisconnect(int iClient)
 								EWM_Chat_Disconnect_Drop(ItemTest, iClient);
 							} else
 							#endif
+							
 							SDKHooks_DropWeapon(iClient, ItemTest.WeaponID);
 						}
 					}
@@ -816,7 +848,7 @@ public Action OnButtonUse(int iButton, int iActivator, int iCaller, UseType uTyp
 										EWM_ELogs_Use(ItemTest, iActivator);
 										#endif
 										#if defined EW_MODULE_CHAT
-										if(ItemTest.Chat) EWM_Chat_Use(ItemTest, iActivator);
+										EWM_Chat_Use(ItemTest, iActivator);
 										#endif
 										
 										ItemTest.Delay = 1;
@@ -831,7 +863,7 @@ public Action OnButtonUse(int iButton, int iActivator, int iCaller, UseType uTyp
 										EWM_ELogs_Use(ItemTest, iActivator);
 										#endif
 										#if defined EW_MODULE_CHAT
-										if(ItemTest.Chat) EWM_Chat_Use(ItemTest, iActivator);
+										EWM_Chat_Use(ItemTest, iActivator);
 										#endif
 										
 										ItemTest.Delay = 1;
@@ -846,7 +878,7 @@ public Action OnButtonUse(int iButton, int iActivator, int iCaller, UseType uTyp
 										EWM_ELogs_Use(ItemTest, iActivator);
 										#endif
 										#if defined EW_MODULE_CHAT
-										if(ItemTest.Chat) EWM_Chat_Use(ItemTest, iActivator);
+										EWM_Chat_Use(ItemTest, iActivator);
 										#endif
 										
 										ItemTest.Delay = 1;
@@ -862,7 +894,7 @@ public Action OnButtonUse(int iButton, int iActivator, int iCaller, UseType uTyp
 										EWM_ELogs_Use(ItemTest, iActivator);
 										#endif
 										#if defined EW_MODULE_CHAT
-										if(ItemTest.Chat) EWM_Chat_Use(ItemTest, iActivator);
+										EWM_Chat_Use(ItemTest, iActivator);
 										#endif
 										
 										ItemTest.Delay = 1;
@@ -1007,6 +1039,10 @@ public Action OnWeaponDrop(int iClient, int iWeapon)
 				#if defined EW_MODULE_CHAT
 				if(ItemTest.Chat) EWM_Chat_Drop(ItemTest, iClient);
 				#endif
+				
+				#if defined EW_MODULE_CLANTAG
+				EWM_Clantag_Drop(ItemTest, iClient);
+				#endif
 					
 				break;
 			}
@@ -1070,6 +1106,11 @@ public Action OnWeaponEquip(int iClient, int iWeapon)
 				#if defined EW_MODULE_CHAT
 				if(ItemTest.Chat) EWM_Chat_PickUp(ItemTest, iClient);
 				#endif
+				
+				#if defined EW_MODULE_CLANTAG
+				if(ItemTest.Hud) EWM_Clantag_PickUp(ItemTest, iClient);
+				#endif
+				
 				#if defined EW_MODULE_OFFLINE_EBAN
 				EWM_OffilneEban_UpdateItemName(iClient, ItemTest.Name);
 				#endif


### PR DESCRIPTION
-> Add Clantag module as alternative HUD

-> Add new glow options to prevent glow on spawn or on drop

-> Add command overrides for bans to prevent lower level admins from perma banning

-> Remove chat requirement for item uses (for maps like Minas Tirith where you want to see barricade usage but not pickup or drops)