### PR TITLE
Fix SM 1.11 Entwatch Compile Errors/Warnings

### DIFF
--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
@@ -13,7 +13,7 @@ stock void EWM_Clantag_OnPluginStart()
 }
 
 //Get Client ClanTag on Connect
-public Action Event_PlayerConnectFull(Event hEvent, const char[] sName, bool bDontBroadcast)
+public void Event_PlayerConnectFull(Event hEvent, const char[] sName, bool bDontBroadcast)
 {
 	int iClient = GetClientOfUserId(GetEventInt(hEvent, "userid"));
 	

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_debug.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_debug.inc
@@ -23,6 +23,7 @@ public Action Command_DebugConfig(int iClient, int iArgs)
 			#endif
 		}
 	}
+	return Plugin_Continue;
 }
 
 public Action Command_DebugArray(int iClient, int iArgs)
@@ -47,6 +48,7 @@ public Action Command_DebugArray(int iClient, int iArgs)
 			#endif
 		}
 	}
+	return Plugin_Continue;
 }
 
 public Action Command_DebugScheme(int iClient, int iArgs)
@@ -58,4 +60,5 @@ public Action Command_DebugScheme(int iClient, int iArgs)
 		CPrintToChat(iClient, "%s[DEBUG] %sColor: R-%i G-%i B-%i A-%i Pos: X-%.4f Y-%.4f",g_SchemeConfig.Color_Tag, g_SchemeConfig.Color_Warning, g_SchemeConfig.Color_HUD[0], g_SchemeConfig.Color_HUD[1], g_SchemeConfig.Color_HUD[2], g_SchemeConfig.Color_HUD[3], g_SchemeConfig.Pos_HUD_X, g_SchemeConfig.Pos_HUD_Y);
 		#endif
 	}
+	return Plugin_Continue;
 }

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_eban.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_eban.inc
@@ -791,4 +791,5 @@ public int EWM_Eban_Menu_EBanReason_Handler(Menu hMenu, MenuAction hAction, int 
 				CPrintToChat(iClient, "%s%t %s%t", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Warning, "Player is not valid anymore");
 		}
 	}
+	return 0;
 }

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_menu.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_menu.inc
@@ -516,6 +516,7 @@ public int EWM_Menu_PM_ItemList_Handler(Menu hMenu, MenuAction hAction, int iCli
 			}
 		}
 	}
+	return 0;
 }
 
 #if defined EW_MODULE_EBAN
@@ -541,6 +542,7 @@ public int EWM_Menu_PM_EBanList_Handler(Menu hMenu, MenuAction hAction, int iCli
 			}
 		}
 	}
+	return 0;
 }
 
 public int EWM_Menu_PM_EUnBanList_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -565,6 +567,7 @@ public int EWM_Menu_PM_EUnBanList_Handler(Menu hMenu, MenuAction hAction, int iC
 			}
 		}
 	}
+	return 0;
 }
 
 public int EWM_Menu_PM_EBanDuration_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -591,6 +594,7 @@ public int EWM_Menu_PM_EBanDuration_Handler(Menu hMenu, MenuAction hAction, int 
 			}
 		}
 	}
+	return 0;
 }
 
 public int EWM_Menu_PM_EBanReason_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -618,6 +622,7 @@ public int EWM_Menu_PM_EBanReason_Handler(Menu hMenu, MenuAction hAction, int iC
 			}
 		}
 	}
+	return 0;
 }
 
 public int EWM_Menu_PM_EBanInfo_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -642,6 +647,7 @@ public int EWM_Menu_PM_EBanInfo_Handler(Menu hMenu, MenuAction hAction, int iCli
 			}
 		}
 	}
+	return 0;
 }
 #endif
 
@@ -665,7 +671,7 @@ public int EWM_Menu_PM_ItemInfo_Handler(Menu hMenu, MenuAction hAction, int iCli
 				if(!IsValidClient(iTarget))
 				{
 					CPrintToChat(iClient, "%s%t %s%t", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Warning, "Player is not valid anymore");
-					return;
+					return 0;
 				}
 				EWM_Menu_PM_EBanDuration(iClient, iTarget);
 			}
@@ -675,6 +681,7 @@ public int EWM_Menu_PM_ItemInfo_Handler(Menu hMenu, MenuAction hAction, int iCli
 			#endif
 		}
 	}
+	return 0;
 }
 
 #if defined EW_MODULE_TRANSFER
@@ -694,11 +701,12 @@ public int EWM_Menu_PM_ItemTransfer_Handler(Menu hMenu, MenuAction hAction, int 
 			if(!IsValidClient(iReceiver))
 			{
 				CPrintToChat(iClient, "%s%t %s%t", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Warning, "Receiver is not valid anymore");
-				return;
+				return 0;
 			}
 			EWM_Transfer_Function(iClient, iItemIndex, iReceiver, true);
 		}
 	}
+	return 0;
 }
 #endif
 
@@ -717,6 +725,7 @@ public int EWM_Menu_PM_SpawnItemList_Handler(Menu hMenu, MenuAction hAction, int
 			EWM_Menu_PM_SpawnItemStrip(iClient, iIndexItem);
 		}
 	}
+	return 0;
 }
 
 public int EWM_Menu_PM_SpawnItemStrip_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -735,6 +744,7 @@ public int EWM_Menu_PM_SpawnItemStrip_Handler(Menu hMenu, MenuAction hAction, in
 			EWM_Menu_PM_SpawnItemTarget(iClient, iItemIndex, iStrip);
 		}
 	}
+	return 0;
 }
 
 public int EWM_Menu_PM_SpawnItemTarget_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -756,5 +766,6 @@ public int EWM_Menu_PM_SpawnItemTarget_Handler(Menu hMenu, MenuAction hAction, i
 			EWM_Spawn_Spawn(iClient, iUserID, iItemIndex, bStrip);
 		}
 	}
+	return 0;
 }
 #endif

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_offline_eban.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_offline_eban.inc
@@ -367,6 +367,7 @@ public int EWM_OfflineEban_PlayerList_Handler(Menu hMenu, MenuAction hAction, in
 			}
 		}
 	}
+	return 0;
 }
 
 public int EWM_OfflineEban_Player_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -382,6 +383,7 @@ public int EWM_OfflineEban_Player_Handler(Menu hMenu, MenuAction hAction, int iC
 			if(StringToInt(sOption) == 777) EWM_OfflineEban_Duration(iClient);
 		}
 	}
+	return 0;
 }
 
 public int EWM_OfflineEban_Duration_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -416,6 +418,7 @@ public int EWM_OfflineEban_Duration_Handler(Menu hMenu, MenuAction hAction, int 
 			if(bAccessDuration) EWM_OfflineEban_Reason(iClient, iDuration);
 		}
 	}
+	return 0;
 }
 
 public int EWM_OfflineEban_Reason_Handler(Menu hMenu, MenuAction hAction, int iClient, int iParam2)
@@ -434,6 +437,7 @@ public int EWM_OfflineEban_Reason_Handler(Menu hMenu, MenuAction hAction, int iC
 			EWM_OfflineEban_BanClient(g_aMenuBuffer[iClient], iClient, iDuration, sReason);
 		}
 	}
+	return 0;
 }
 
 //-------------------------------------------------------

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_spawn_item.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_spawn_item.inc
@@ -186,9 +186,10 @@ public int EWM_Spawn_EdictMenu_Handler(Menu hEdictMenu, MenuAction hAction, int 
 			if(!IsValidClient(iTarget))
 			{
 				CPrintToChat(iClient, "%s%t %s%t", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Warning, "Receiver is not valid anymore");
-				return;
+				return 0;
 			}
 			EWM_Spawn_Spawn(iClient, iUserID, iItemIndex, bStrip);
 		}
 	}
+	return 0;
 }

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_transfer.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_transfer.inc
@@ -102,11 +102,12 @@ public int EWM_Transfer_EdictMenu_Handler(Menu hEdictMenu, MenuAction hAction, i
 			if(!IsValidClient(iReceiver))
 			{
 				CPrintToChat(iClient, "%s%t %s%t", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Warning, "Receiver is not valid anymore");
-				return;
+				return 0;
 			}
 			EWM_Transfer_Function(iClient, iItemIndex, iReceiver, true);
 		}
 	}
+	return 0;
 }
 
 public void EWM_Transfer_Function(int iClient, int iItemIndex, int iReceiver, bool bMessageTransfer)

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_use_priority.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_use_priority.inc
@@ -39,7 +39,7 @@ stock void EWM_Use_Priority_LoadDefaultClientSettings(int iClient)
 	g_bUsePriorityClient[iClient] = true;
 }
 
-public Action OnPlayerRunCmd(int iClient, int &iButtons, int &iImpulse, float[3] aVel, float[3] aAngles, int &iWeapon)
+public Action OnPlayerRunCmd(int iClient, int& iButtons, int& impulse, float vel[3], float angles[3], int& weapon, int& subtype, int& cmdnum, int& tickcount, int& seed, int mouse[2])
 {
 	if(iButtons & IN_USE)
 	{

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_use_priority.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_use_priority.inc
@@ -39,7 +39,7 @@ stock void EWM_Use_Priority_LoadDefaultClientSettings(int iClient)
 	g_bUsePriorityClient[iClient] = true;
 }
 
-public Action OnPlayerRunCmd(int iClient, int& iButtons, int& impulse, float vel[3], float angles[3], int& weapon, int& subtype, int& cmdnum, int& tickcount, int& seed, int mouse[2])
+public Action OnPlayerRunCmd(int iClient, int& iButtons, int& iImpulse, float aVel[3], float aAngles[3], int& iWeapon)
 {
 	if(iButtons & IN_USE)
 	{

--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch_csgo_dz.sp
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch_csgo_dz.sp
@@ -220,7 +220,7 @@ public void OnMapEnd()
 	#endif
 }
 
-public Action Event_RoundStart(Event hEvent, const char[] sName, bool bDontBroadcast)
+public void Event_RoundStart(Event hEvent, const char[] sName, bool bDontBroadcast)
 {
 	if(g_bConfigLoaded) CPrintToChatAll("%s%t %s%t", g_SchemeConfig.Color_Tag, "EW_Tag", g_SchemeConfig.Color_Warning, "Welcome");
 	
@@ -229,7 +229,7 @@ public Action Event_RoundStart(Event hEvent, const char[] sName, bool bDontBroad
 	#endif
 }
 
-public Action Event_RoundEnd(Event hEvent, const char[] sName, bool bDontBroadcast)
+public void Event_RoundEnd(Event hEvent, const char[] sName, bool bDontBroadcast)
 {
 	if(g_bConfigLoaded) 
 	{
@@ -905,7 +905,7 @@ public void OnMathSpawned(int iEntity)
 
 public Action Timer_OnMathSpawned(Handle timer, int iEntity)
 {
-	if(!IsValidEntity(iEntity) || !g_bConfigLoaded) return;
+	if(!IsValidEntity(iEntity) || !g_bConfigLoaded) return Plugin_Stop;
 	
 	for(int i = 0; i < g_ItemList.Length; i++)
 	{
@@ -914,9 +914,10 @@ public Action Timer_OnMathSpawned(Handle timer, int iEntity)
 		if (RegisterMath(ItemTest, iEntity))
 		{
 			g_ItemList.SetArray(i, ItemTest, sizeof(ItemTest));
-			return;
+			return Plugin_Stop;
 		}
 	}
+	return Plugin_Stop;
 }
 
 public void OnButtonSpawned(int iEntity) //Button with parent spawns after weapon entity. With timer button don't register if item spawns with module items_spawn
@@ -952,7 +953,7 @@ public void OnTriggerSpawned(int iEntity)
 
 public Action Timer_OnTriggerSpawned(Handle timer, int iEntity)
 {
-	if(!IsValidEntity(iEntity) || !g_bConfigLoaded) return;
+	if(!IsValidEntity(iEntity) || !g_bConfigLoaded) return Plugin_Stop;
 	
 	int iHammerID = Entity_GetHammerID(iEntity);
 	if(iHammerID>0)
@@ -970,6 +971,7 @@ public Action Timer_OnTriggerSpawned(Handle timer, int iEntity)
 			}
 		}
 	}
+	return Plugin_Stop;
 }
 
 public Action OnTrigger(int iEntity, int iClient)
@@ -1136,7 +1138,7 @@ public Action OnButtonUse(int iButton, int iActivator, int iCaller, UseType uTyp
 //-------------------------------------------------------
 //Purpose: Update item energy from math counter
 //-------------------------------------------------------
-public Action Event_OutValue(const char[] sOutput, int iCaller, int iActivator, float Delay)
+public void Event_OutValue(const char[] sOutput, int iCaller, int iActivator, float Delay)
 {
 	for(int i = 0; i < g_ItemList.Length; i++)
 	{
@@ -1272,7 +1274,7 @@ public Action Event_GameUI_RightClick(const char[] sOutput, int iCaller, int iAc
 //-------------------------------------------------------
 //Purpose: Notify when they drop a special weapon
 //-------------------------------------------------------
-public Action OnWeaponDrop(int iClient, int iWeapon)
+public void OnWeaponDrop(int iClient, int iWeapon)
 {
 	if(g_bConfigLoaded && IsValidEdict(iWeapon))
 	{
@@ -1337,7 +1339,7 @@ public Action OnWeaponCanUse(int iClient, int iWeapon)
 //-------------------------------------------------------
 //Purpose: Notify when they pick up a special weapon
 //-------------------------------------------------------
-public Action OnWeaponEquip(int iClient, int iWeapon)
+public void OnWeaponEquip(int iClient, int iWeapon)
 {
 	if(g_bConfigLoaded && IsValidEdict(iWeapon))
 	{


### PR DESCRIPTION
The current code in `entwatch/module_use_priority.inc` on lline 42 for the `OnPlayerRunCmd` function will cause an error when compiling:

```
entwatch\module_use_priority.inc(42) : error 101: fixed dimensions must be after the array name, not on the type
```

I have also gone ahead and resolved various compilation warnings that SM 1.11 compiler will report.