### PR TITLE
Fix clan tag module

### DIFF
--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch/module_clantag.inc
@@ -21,9 +21,14 @@ public void Event_PlayerConnectFull(Event hEvent, const char[] sName, bool bDont
 }
 
 //Get Client ClanTag on Change
-public void OnClientSettingsChanged(int iClient)
+public void OnClientCommandKeyValues_Post(int iClient, KeyValues kv)
 {
-	if(IsValidClient(iClient)) CS_GetClientClanTag(iClient, g_sClanTag[iClient], MAXSIZECLANTAG);
+	if(IsValidClient(iClient))
+	{
+		char sCommmand[32];
+		if (kv.GetSectionName(sCommmand, sizeof(sCommmand)) && strcmp(sCommmand, "ClanTagChanged", false) == 0)
+			kv.GetString("tag", g_sClanTag[iClient], MAXSIZECLANTAG);
+	}
 }
 
 //Clear stored ClanTag


### PR DESCRIPTION
Changing the method of how the clan tag is retrieved when changed through settings menu.
There is an edge case where `OnClientSettingsChanged` is "falsely" called through `setinfo` and thus could potentially store the clan tag of an actual item name. So when the item is dropped/removed etc. it would reset to the wrong clan tag.

A way to reproduce that bug is by using GFL's transparency models and the config provided to toggle the transparency levels
https://gflclan.com/topic/44920-transparency-player-models-updated-20220221/?do=findComment&comment=348175

Fix found & taken from Kxnrl entWatch fork so credits go to him :) https://github.com/Kxnrl/entWatch/blob/9e6ba5826173c4f3379216aaca55b283dd845621/entWatch.sp#L672