### PR TITLE
Fix energy id bug

### DIFF
--- a/EntWatch_DZ/addons/sourcemod/scripting/entwatch_csgo_dz.sp
+++ b/EntWatch_DZ/addons/sourcemod/scripting/entwatch_csgo_dz.sp
@@ -1012,7 +1012,7 @@ public void OnItemSpawned(int iEntity)
 public void OnMathSpawned(int iEntity)
 {
 	//In case the math entity spawns just before the weapon entity (?)
-	CreateTimer(0.5, Timer_OnMathSpawned, iEntity);
+	CreateTimer(1.5, Timer_OnMathSpawned, iEntity);
 	
 }
 


### PR DESCRIPTION
The delay of 0.5 seconds is too small, at that point in time items themselves are not registered yet (math_counter spawning earlier than anything else?).
Thanks to SnowyGFL for debugging help.